### PR TITLE
Validate retry after headers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -598,8 +598,9 @@ export class Dinari {
     // Note the `retry-after-ms` header may not be standard, but is a good idea and we'd like proactive support for it.
     const retryAfterMillisHeader = responseHeaders?.get('retry-after-ms');
     if (retryAfterMillisHeader) {
-      const timeoutMs = parseFloat(retryAfterMillisHeader);
-      if (!Number.isNaN(timeoutMs)) {
+      const trimmedHeader = retryAfterMillisHeader.trim();
+      const timeoutMs = Number(trimmedHeader);
+      if (trimmedHeader !== '' && Number.isFinite(timeoutMs) && timeoutMs >= 0) {
         timeoutMillis = timeoutMs;
       }
     }
@@ -607,11 +608,14 @@ export class Dinari {
     // About the Retry-After header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
     const retryAfterHeader = responseHeaders?.get('retry-after');
     if (retryAfterHeader && !timeoutMillis) {
-      const timeoutSeconds = parseFloat(retryAfterHeader);
-      if (!Number.isNaN(timeoutSeconds)) {
-        timeoutMillis = timeoutSeconds * 1000;
+      const trimmedHeader = retryAfterHeader.trim();
+      if (/^\d+$/.test(trimmedHeader)) {
+        timeoutMillis = Number(trimmedHeader) * 1000;
       } else {
-        timeoutMillis = Date.parse(retryAfterHeader) - Date.now();
+        const retryDate = Date.parse(trimmedHeader);
+        if (!Number.isNaN(retryDate)) {
+          timeoutMillis = retryDate - Date.now();
+        }
       }
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -813,6 +813,31 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('retry on 429 ignores malformed retry-after', async () => {
+    let count = 0;
+    const testFetch = async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+      count++;
+      if (count === 1) {
+        return new Response(undefined, {
+          status: 429,
+          headers: {
+            'Retry-After': '0.1abc',
+          },
+        });
+      }
+      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const client = new Dinari({
+      apiKeyID: 'My API Key ID',
+      apiSecretKey: 'My API Secret Key',
+      fetch: testFetch,
+    });
+
+    expect(await client.request({ path: '/foo', method: 'get' })).toEqual({ a: 1 });
+    expect(count).toEqual(2);
+  });
+
   test('retry on 429 with retry-after-ms', async () => {
     let count = 0;
     const testFetch = async (


### PR DESCRIPTION
Retry header parsing now requires complete valid numeric values before using them as retry delays. Malformed values like `0.1abc` fall back to the default retry delay instead of being partially parsed.

This preserves valid retry-after-ms and retry-after behavior while avoiding unintended waits from invalid header values.